### PR TITLE
Address review comments: replace FQN with imports, parameterize tests

### DIFF
--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/SparkHoodieTableFileIndex.scala
@@ -50,13 +50,15 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, BasePredic
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.datasources.{FileStatusCache, NoopCache}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ByteType, DateType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{ByteType, DataType, DateType, IntegerType, LongType, ShortType, StringType, StructField, StructType}
 import org.slf4j.LoggerFactory
 
 import javax.annotation.concurrent.NotThreadSafe
 
 import java.lang.reflect.{Array => JArray}
 import java.util.Collections
+
+import scala.collection.mutable.LinkedHashMap
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
@@ -535,8 +537,8 @@ object SparkHoodieTableFileIndex extends SparkAdapterSupport {
   private val PUT_LEAF_FILES_METHOD_NAME = "putLeafFiles"
 
   private case class NestedFieldNode(
-      leafType: Option[org.apache.spark.sql.types.DataType],
-      children: scala.collection.mutable.LinkedHashMap[String, NestedFieldNode]
+      leafType: Option[DataType],
+      children: LinkedHashMap[String, NestedFieldNode]
   )
 
   /**
@@ -553,10 +555,10 @@ object SparkHoodieTableFileIndex extends SparkAdapterSupport {
     if (flatPartitionSchema.isEmpty) {
       new StructType()
     } else {
-      val root = NestedFieldNode(None, scala.collection.mutable.LinkedHashMap.empty)
+      val root = NestedFieldNode(None, LinkedHashMap.empty)
 
       def getOrCreateChild(parent: NestedFieldNode, name: String): NestedFieldNode = {
-        parent.children.getOrElseUpdate(name, NestedFieldNode(None, scala.collection.mutable.LinkedHashMap.empty))
+        parent.children.getOrElseUpdate(name, NestedFieldNode(None, LinkedHashMap.empty))
       }
 
       flatPartitionSchema.fields.foreach { field =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/TestHoodieFileIndex.scala
@@ -44,7 +44,7 @@ import org.apache.hudi.testutils.HoodieSparkClientTestBase
 import org.apache.hudi.util.JFunction
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, GetStructField, GreaterThanOrEqual, LessThan, Literal, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Expression, GetStructField, GreaterThanOrEqual, LessThan, Literal, Or}
 import org.apache.spark.sql.execution.datasources.{NoopCache, PartitionDirectory}
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
@@ -861,65 +861,10 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
 
   // ---- buildNestedPartitionSchema tests ----
 
-  @Test
-  def testBuildNestedPartitionSchemaEmpty(): Unit = {
-    val result = SparkHoodieTableFileIndex.buildNestedPartitionSchema(new StructType())
-    assertTrue(result.isEmpty)
-  }
-
-  @Test
-  def testBuildNestedPartitionSchemaFlatColumn(): Unit = {
-    val flat = StructType(Seq(StructField("country", StringType)))
-    val result = SparkHoodieTableFileIndex.buildNestedPartitionSchema(flat)
-    assertEquals(StructType(Seq(StructField("country", StringType, nullable = true))), result)
-  }
-
-  @Test
-  def testBuildNestedPartitionSchemaSingleNested(): Unit = {
-    // "nested_record.level" → StructType(nested_record: StructType(level: StringType))
-    val flat = StructType(Seq(StructField("nested_record.level", StringType)))
-    val result = SparkHoodieTableFileIndex.buildNestedPartitionSchema(flat)
-    assertEquals(1, result.fields.length)
-    assertEquals("nested_record", result.fields(0).name)
-    val inner = result.fields(0).dataType.asInstanceOf[StructType]
-    assertEquals(StructType(Seq(StructField("level", StringType, nullable = true))), inner)
-  }
-
-  @Test
-  def testBuildNestedPartitionSchemaTwoLevelNesting(): Unit = {
-    // "a.b.c" → StructType(a: StructType(b: StructType(c: IntegerType)))
-    val flat = StructType(Seq(StructField("a.b.c", IntegerType)))
-    val result = SparkHoodieTableFileIndex.buildNestedPartitionSchema(flat)
-    val a = result.fields(0)
-    assertEquals("a", a.name)
-    val b = a.dataType.asInstanceOf[StructType].fields(0)
-    assertEquals("b", b.name)
-    val c = b.dataType.asInstanceOf[StructType].fields(0)
-    assertEquals("c", c.name)
-    assertEquals(IntegerType, c.dataType)
-  }
-
-  @Test
-  def testBuildNestedPartitionSchemaSiblingFields(): Unit = {
-    // "a.b" and "a.c" share parent "a"
-    val flat = StructType(Seq(StructField("a.b", StringType), StructField("a.c", IntegerType)))
-    val result = SparkHoodieTableFileIndex.buildNestedPartitionSchema(flat)
-    assertEquals(1, result.fields.length)
-    val inner = result.fields(0).dataType.asInstanceOf[StructType]
-    assertEquals(2, inner.fields.length)
-    assertEquals("b", inner.fields(0).name)
-    assertEquals("c", inner.fields(1).name)
-  }
-
-  @Test
-  def testBuildNestedPartitionSchemaMixedFlatAndNested(): Unit = {
-    val flat = StructType(Seq(StructField("country", StringType), StructField("nested_record.level", StringType)))
-    val result = SparkHoodieTableFileIndex.buildNestedPartitionSchema(flat)
-    assertEquals(2, result.fields.length)
-    assertEquals("country", result.fields(0).name)
-    assertEquals(StringType, result.fields(0).dataType)
-    assertEquals("nested_record", result.fields(1).name)
-    assertTrue(result.fields(1).dataType.isInstanceOf[StructType])
+  @ParameterizedTest
+  @MethodSource(Array("buildNestedPartitionSchemaCases"))
+  def testBuildNestedPartitionSchema(name: String, flat: StructType, expected: StructType): Unit = {
+    assertEquals(expected, SparkHoodieTableFileIndex.buildNestedPartitionSchema(flat))
   }
 
   @Test
@@ -933,37 +878,13 @@ class TestHoodieFileIndex extends HoodieSparkClientTestBase with ScalaAssertionS
 
   // ---- extractNestedPartitionFilters tests ----
 
-  @Test
-  def testExtractNestedPartitionFiltersCorrectFilterExtracted(): Unit = {
-    // nested_record.level = 'INFO' → extracted; int_field = 5 → excluded
-    val structType = StructType(Seq(StructField("level", StringType)))
-    val gsf = GetStructField(AttributeReference("nested_record", structType)(), 0, Some("level"))
-    val partFilter = EqualTo(gsf, Literal("INFO"))
-    val dataFilter = EqualTo(AttributeReference("int_field", IntegerType)(), Literal(5))
-    val result = HoodieFileIndex.extractNestedPartitionFilters(Seq(partFilter, dataFilter), Set("nested_record.level"))
-    assertEquals(1, result.size)
-    assertEquals(partFilter, result.head)
-  }
-
-  @Test
-  def testExtractNestedPartitionFiltersSiblingFieldExcluded(): Unit = {
-    // nested_record.nested_int = 10 should NOT match partition column nested_record.level
-    val structType = StructType(Seq(StructField("nested_int", IntegerType), StructField("level", StringType)))
-    val gsf = GetStructField(AttributeReference("nested_record", structType)(), 0, Some("nested_int"))
-    val filter = EqualTo(gsf, Literal(10))
-    val result = HoodieFileIndex.extractNestedPartitionFilters(Seq(filter), Set("nested_record.level"))
-    assertTrue(result.isEmpty)
-  }
-
-  @Test
-  def testExtractNestedPartitionFiltersOrWithOnlyPartitionColumns(): Unit = {
-    // nested_record.level = 'INFO' OR nested_record.level = 'ERROR' → extracted
-    val structType = StructType(Seq(StructField("level", StringType)))
-    val gsf1 = GetStructField(AttributeReference("nested_record", structType)(), 0, Some("level"))
-    val gsf2 = GetStructField(AttributeReference("nested_record", structType)(), 0, Some("level"))
-    val orExpr = Or(EqualTo(gsf1, Literal("INFO")), EqualTo(gsf2, Literal("ERROR")))
-    val result = HoodieFileIndex.extractNestedPartitionFilters(Seq(orExpr), Set("nested_record.level"))
-    assertEquals(1, result.size)
+  @ParameterizedTest
+  @MethodSource(Array("extractNestedPartitionFiltersCases"))
+  def testExtractNestedPartitionFilters(name: String,
+                                        filters: Seq[Expression],
+                                        partitionColumns: Set[String],
+                                        expected: Seq[Expression]): Unit = {
+    assertEquals(expected, HoodieFileIndex.extractNestedPartitionFilters(filters, partitionColumns))
   }
 
 }
@@ -976,6 +897,67 @@ object TestHoodieFileIndex {
       Arguments.arguments("org.apache.hudi.keygen.ComplexKeyGenerator"),
       Arguments.arguments("org.apache.hudi.keygen.SimpleKeyGenerator"),
       Arguments.arguments("org.apache.hudi.keygen.TimestampBasedKeyGenerator")
+    )
+  }
+
+  def buildNestedPartitionSchemaCases(): java.util.stream.Stream[Arguments] = {
+    val nested = StructType(Seq(
+      StructField("nested_record", StructType(Seq(StructField("level", StringType, nullable = true))), nullable = true)))
+    val twoLevel = StructType(Seq(
+      StructField("a", StructType(Seq(
+        StructField("b", StructType(Seq(StructField("c", IntegerType, nullable = true))), nullable = true))), nullable = true)))
+    val siblings = StructType(Seq(
+      StructField("a", StructType(Seq(
+        StructField("b", StringType, nullable = true),
+        StructField("c", IntegerType, nullable = true))), nullable = true)))
+    val mixed = StructType(Seq(
+      StructField("country", StringType, nullable = true),
+      StructField("nested_record", StructType(Seq(StructField("level", StringType, nullable = true))), nullable = true)))
+    java.util.stream.Stream.of(
+      Arguments.of("empty",
+        new StructType(),
+        new StructType()),
+      Arguments.of("flat",
+        StructType(Seq(StructField("country", StringType))),
+        StructType(Seq(StructField("country", StringType, nullable = true)))),
+      Arguments.of("singleNested",
+        StructType(Seq(StructField("nested_record.level", StringType))),
+        nested),
+      Arguments.of("twoLevelNesting",
+        StructType(Seq(StructField("a.b.c", IntegerType))),
+        twoLevel),
+      Arguments.of("siblingFields",
+        StructType(Seq(StructField("a.b", StringType), StructField("a.c", IntegerType))),
+        siblings),
+      Arguments.of("mixedFlatAndNested",
+        StructType(Seq(StructField("country", StringType), StructField("nested_record.level", StringType))),
+        mixed)
+    )
+  }
+
+  def extractNestedPartitionFiltersCases(): java.util.stream.Stream[Arguments] = {
+    val levelStruct = StructType(Seq(StructField("level", StringType)))
+    val multiFieldStruct = StructType(Seq(
+      StructField("nested_int", IntegerType), StructField("level", StringType)))
+
+    val partFilter = EqualTo(
+      GetStructField(AttributeReference("nested_record", levelStruct)(), 0, Some("level")),
+      Literal("INFO"))
+    val dataFilter = EqualTo(AttributeReference("int_field", IntegerType)(), Literal(5))
+    val siblingFilter = EqualTo(
+      GetStructField(AttributeReference("nested_record", multiFieldStruct)(), 0, Some("nested_int")),
+      Literal(10))
+    val orFilter = Or(
+      EqualTo(GetStructField(AttributeReference("nested_record", levelStruct)(), 0, Some("level")), Literal("INFO")),
+      EqualTo(GetStructField(AttributeReference("nested_record", levelStruct)(), 0, Some("level")), Literal("ERROR")))
+
+    java.util.stream.Stream.of(
+      Arguments.of("partitionFilterExtractedDataFilterDropped",
+        Seq(partFilter, dataFilter), Set("nested_record.level"), Seq(partFilter)),
+      Arguments.of("siblingFieldExcluded",
+        Seq(siblingFilter), Set("nested_record.level"), Seq.empty[Expression]),
+      Arguments.of("orWithOnlyPartitionColumnsExtracted",
+        Seq(orFilter), Set("nested_record.level"), Seq(orFilter))
     )
   }
 }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestCOWDataSource.scala
@@ -46,9 +46,11 @@ import org.apache.hudi.storage.{HoodieStorage, StoragePath, StoragePathFilter}
 import org.apache.hudi.table.HoodieSparkTable
 import org.apache.hudi.testutils.{DataSourceTestUtils, HoodieSparkClientTestBase}
 import org.apache.hudi.util.JFunction
+import org.apache.hudi.{HoodieBaseRelation, HoodieFileIndex}
 
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Dataset, Encoders, Row, SaveMode, SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions.{col, concat, lit, udf, when}
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.types.{ArrayType, DataTypes, DateType, IntegerType, LongType, MapType, StringType, StructField, StructType, TimestampType}
@@ -2740,13 +2742,13 @@ object TestCOWDataSource {
 
     // VERIFICATION 1: Check partition schema contains the nested field
     val snapshotRelation = snapshotDF.queryExecution.optimizedPlan.collectFirst {
-      case lr: org.apache.spark.sql.execution.datasources.LogicalRelation => lr
+      case lr: LogicalRelation => lr
     }
     assertTrue(snapshotRelation.isDefined, s"LogicalRelation should exist for $tableType")
     val fileIndex = snapshotRelation.get.relation match {
-      case fsRelation: org.apache.spark.sql.execution.datasources.HadoopFsRelation =>
-        fsRelation.location.asInstanceOf[org.apache.hudi.HoodieFileIndex]
-      case baseRelation: org.apache.hudi.HoodieBaseRelation =>
+      case fsRelation: HadoopFsRelation =>
+        fsRelation.location.asInstanceOf[HoodieFileIndex]
+      case baseRelation: HoodieBaseRelation =>
         baseRelation.fileIndex
       case _ => null
     }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

Follow-up to review comments on apache/hudi#18126, specifically https://github.com/apache/hudi/pull/18126#pullrequestreview-4301069264 and the test-redundancy discussion. Targets your PR branch so the changes flow into #18126.

### Summary and Changelog

- `SparkHoodieTableFileIndex`: import `DataType` and `LinkedHashMap` at the top of the file; drop the inline `org.apache.spark.sql.types.DataType` / `scala.collection.mutable.LinkedHashMap` qualifiers in `NestedFieldNode` and `buildNestedPartitionSchema`.
- `TestCOWDataSource`: import `LogicalRelation`, `HadoopFsRelation`, `HoodieFileIndex`, `HoodieBaseRelation`; drop the inline FQN usages in `runNestedFieldPartitionTest`.
- `TestHoodieFileIndex`: collapse 6 `testBuildNestedPartitionSchema*` cases into a single `@ParameterizedTest` driven by `buildNestedPartitionSchemaCases`, and 3 `testExtractNestedPartitionFilters*` cases into `extractNestedPartitionFiltersCases`. The conflict-throws case stays as a focused `@Test` since its shape differs.

Net change: -100 / +86 (mostly test consolidation).

### Impact

Test-only and import-style refactor. No behavior change.

### Risk Level

none

### Documentation Update

none

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable